### PR TITLE
Save nyuki config with right delimiters to have a readable file.

### DIFF
--- a/examples/sample.json
+++ b/examples/sample.json
@@ -1,11 +1,44 @@
 {
-  "bus": {
-    "jid": "sample@localhost",
-    "password": "sample"
-  },
-  "api": {
-    "host": "0.0.0.0",
-    "port": 5558
-  },
-  "port": 4000
+    "api": {
+        "host": "0.0.0.0",
+        "port": 5558
+    },
+    "bus": {
+        "jid": "sample@localhost",
+        "password": "sample"
+    },
+    "log": {
+        "disable_existing_loggers": false,
+        "formatters": {
+            "long": {
+                "format": "%(asctime)-24s %(levelname)-8s [%(name)s] %(message)s"
+            }
+        },
+        "handlers": {
+            "console": {
+                "class": "logging.StreamHandler",
+                "formatter": "long",
+                "stream": "ext://sys.stdout"
+            }
+        },
+        "loggers": {
+            "aiohttp.web": {
+                "level": "WARNING"
+            },
+            "asyncio": {
+                "level": "WARNING"
+            },
+            "slixmpp": {
+                "level": "WARNING"
+            }
+        },
+        "root": {
+            "handlers": [
+                "console"
+            ],
+            "level": "INFO"
+        },
+        "version": 1
+    },
+    "port": 4000
 }

--- a/examples/sender.json
+++ b/examples/sender.json
@@ -1,6 +1,6 @@
 {
-  "bus": {
-    "jid": "sender@localhost",
-    "password": "sender"
-  }
+    "bus": {
+        "jid": "sender@localhost",
+        "password": "sender"
+    }
 }

--- a/nyuki/config.py
+++ b/nyuki/config.py
@@ -90,4 +90,5 @@ def write_conf_json(config, filename):
     Save the given configuration to a file in json format.
     """
     with open(filename, 'w') as jsonfile:
-        json.dump(config, jsonfile)
+        json.dump(config, jsonfile,
+                  sort_keys=True, indent=2, separators=(',', ': '))

--- a/nyuki/config.py
+++ b/nyuki/config.py
@@ -91,4 +91,4 @@ def write_conf_json(config, filename):
     """
     with open(filename, 'w') as jsonfile:
         json.dump(config, jsonfile,
-                  sort_keys=True, indent=2, separators=(',', ': '))
+                  sort_keys=True, indent=4, separators=(',', ': '))


### PR DESCRIPTION
to test:
in examples:

python sample.py -c sample.json

```bash
curl -XPATCH http://0.0.0.0:5558/v1/config -H "CONTENT-TYPE :application/json" -d '{"siu_type":"S12", "test": {"fields": {"start_date_time":"2015-10-01T18:05:00"}}}'
```

check config is readable