### PR TITLE
Bodyless request on POST-like method

### DIFF
--- a/examples/sample.py
+++ b/examples/sample.py
@@ -45,8 +45,8 @@ class Sample(Nyuki):
                 return Response(status=404)
             return Response({'message': self.messages[mid]})
 
-        def post(self, request):
-            self.message = request['message']
+        def post(self, request, mid):
+            self.message[mid] = request['message']
             log.info("Message updated")
             return Response(status=200)
 
@@ -55,15 +55,9 @@ class Sample(Nyuki):
         def get(self, request, mid, letter):
             return Response({'letter': self.messages[mid][int(letter)]})
 
-        def post(self, request):
-            self.message = request['message']
-            log.info("Message updated")
-            return Response(status=200)
-
-    @resource(endpoint='/alert')
-    class Alert:
-        def post(self, request):
-            self.send(request, 'toto@localhost', 'do_something')
+        def post(self, request, mid, letter):
+            self.message[mid][letter] = request['letter']
+            log.info("Letter updated")
             return Response(status=200)
 
     def teardown(self):

--- a/nyuki/api.py
+++ b/nyuki/api.py
@@ -41,7 +41,6 @@ class Api(object):
         self._handler = None
         self._middlewares = [mw_json, mw_capability]  # Call order = list order
         self._debug = debug
-        print("##### {}".format(debug))
         self._app = web.Application(
             loop=self._loop,
             middlewares=self._middlewares,

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -158,25 +158,3 @@ class TestCapabilityMiddleware(AsyncTestCase):
         assert_true(isinstance(response, web.Response))
         eq_(loads(response.body.decode('utf-8'))["response"], 2)
         eq_(response.status, 200)
-
-    def test_002_error_handling_post_method_no_json(self):
-        self._request.method = 'POST'
-        data = 'data_no_json'
-
-        @fake_future
-        def json():
-            return loads(data)
-
-        self._request.json = json
-
-        @fake_future
-        def _capa_handler():
-            pass
-
-        mdw = self._loop.run_until_complete(
-            mw_capability(self._app, _capa_handler))
-        assert_is_not_none(mdw)
-        assert_raises(
-            errors.BadHttpMessage,
-            self._loop.run_until_complete,
-            mdw(self._request))


### PR DESCRIPTION
Request without payload can now be pushed to the API only if the Content-Type header is not set as there is no content (moreover a minimal json is either `{}` or `[]` according to the [RFC](http://www.ietf.org/rfc/rfc4627.txt))