### PR TITLE
Make use of a real aiohttp Response object on nyuki API

### DIFF
--- a/nyuki/api.py
+++ b/nyuki/api.py
@@ -144,10 +144,9 @@ async def mw_capability(app, capa_handler):
         api_req = await APIRequest.from_request(request)
         capa_resp = await capa_handler(api_req, **request.match_info)
 
-        return web.Response(
-            body=capa_resp.api_payload if capa_resp else None,
-            status=capa_resp.status if capa_resp else 200,
-            headers=capa_resp.headers if capa_resp else {},
-        )
+        if capa_resp and isinstance(capa_resp, web.Response):
+            return capa_resp
+        else:
+            return web.Response()
 
     return middleware

--- a/nyuki/capabilities.py
+++ b/nyuki/capabilities.py
@@ -48,18 +48,20 @@ class Response(web.Response):
     Overrides aiohttp's response to facilitate its usage
     """
 
+    ENCODING = 'utf-8'
+
     def __init__(self, body=None, **kwargs):
 
         # Check json
         if isinstance(body, dict) or isinstance(body, list):
             log.debug('converting dict/list response to bytes')
-            body = json.dumps(body).encode()
+            body = json.dumps(body).encode(self.ENCODING)
             if not self._get_content_type(kwargs):
                 kwargs['content_type'] = 'application/json'
         # Check body
         elif body is not None:
             log.debug('converting string response to bytes')
-            body = str(body).encode()
+            body = str(body).encode(self.ENCODING)
             if not self._get_content_type(kwargs):
                 kwargs['content_type'] = 'text/plain'
 

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -118,7 +118,7 @@ class TestCapabilityMiddleware(TestCase):
         @future_func
         def _capa_handler(d, name):
             eq_(name, 'test')
-            capa_resp = Response({'response': 'ok'}, 200)
+            capa_resp = Response({'response': 'ok'})
             return capa_resp
 
         mdw = await mw_capability(self._app, _capa_handler)
@@ -136,7 +136,7 @@ class TestCapabilityMiddleware(TestCase):
         @future_func
         def _capa_handler(d, name):
             eq_(name, 'test')
-            capa_resp = Response({'response': 2}, 200)
+            capa_resp = Response({'response': 2})
             return capa_resp
 
         mdw = await mw_capability(self._app, _capa_handler)
@@ -159,7 +159,7 @@ class TestCapabilityMiddleware(TestCase):
         @future_func
         def _capa_handler(d, name):
             eq_(name, 'test')
-            capa_resp = Response({'response': 'ok'}, 200)
+            capa_resp = Response({'response': 'ok'})
             return capa_resp
 
         mdw = await mw_capability(self._app, _capa_handler)

--- a/tests/capabilities_test.py
+++ b/tests/capabilities_test.py
@@ -1,3 +1,4 @@
+from nose.tools import eq_
 from unittest import TestCase
 from unittest.mock import Mock, patch
 
@@ -33,22 +34,19 @@ class TestCapability(TestCase):
 
 class TestResponse(TestCase):
 
-    def setUp(self):
-        self.response = Response(body={'message': 'hello'}, status=200)
+    def test_001_dict_body(self):
+        response = Response({'test': 'test'})
+        eq_(response.body, b'{"test": "test"}')
+        eq_(response.content_type, 'application/json')
 
-    def test_001a_valid(self):
-        self.assertIsNone(self.response._validate())
+    def test_002_other_body(self):
+        response = Response(123)
+        eq_(response.body, b'123')
+        eq_(response.content_type, 'text/plain')
 
-    def test_001b_valid_error(self):
-        self.response.body = 'hello'
-        self.assertRaises(ValueError, self.response._validate)
-
-    def test_001c_valid_error(self):
-        self.response.body = '404'
-        self.assertRaises(ValueError, self.response._validate)
-
-    def test_002_payload(self):
-        self.assertIsInstance(self.response.api_payload, bytes)
+        response = Response('hello')
+        eq_(response.body, b'hello')
+        eq_(response.content_type, 'text/plain')
 
 
 class TestExposer(TestCase):

--- a/tests/nyuki_test.py
+++ b/tests/nyuki_test.py
@@ -55,7 +55,7 @@ class TestNyuki(TestCase):
     @ignore_loop
     def test_003_get_rest_configuration(self):
         response = self.nyuki.Configuration.get(self.nyuki, None)
-        eq_(json.loads(bytes.decode(response.api_payload)), self.nyuki._config)
+        eq_(json.loads(bytes.decode(response.body)), self.nyuki._config)
 
     @patch('nyuki.bus.Bus.stop')
     async def test_004_patch_rest_configuration(self, bus_stop_mock):


### PR DESCRIPTION
Allow us to send back any `content-type` and such