### PR TITLE
Add a reporting module wrapping standard messages published by nyukis

### DIFF
--- a/nyuki/api.py
+++ b/nyuki/api.py
@@ -154,10 +154,14 @@ async def mw_capability(app, capa_handler):
         try:
             capa_resp = await capa_handler(api_req, **request.match_info)
         except Exception as exc:
-            app.loop.call_exception_handler({
-                'message': str(exc),
-                'exception': exc
-            })
+            # Access private '_exception_handler' attribute to avoid calling
+            # the 'default_exception_handler' a second time if no exception
+            # handler has been set on our side (no bus)
+            if app.loop._exception_handler:
+                app.loop.call_exception_handler({
+                    'message': str(exc),
+                    'exception': exc
+                })
             raise exc
 
         if capa_resp and isinstance(capa_resp, web.Response):

--- a/nyuki/api.py
+++ b/nyuki/api.py
@@ -150,7 +150,15 @@ async def mw_capability(app, capa_handler):
     """
     async def middleware(request):
         api_req = await APIRequest.from_request(request)
-        capa_resp = await capa_handler(api_req, **request.match_info)
+
+        try:
+            capa_resp = await capa_handler(api_req, **request.match_info)
+        except Exception as exc:
+            app.loop.call_exception_handler({
+                'message': str(exc),
+                'exception': exc
+            })
+            raise exc
 
         if capa_resp and isinstance(capa_resp, web.Response):
             return capa_resp

--- a/nyuki/nyuki.py
+++ b/nyuki/nyuki.py
@@ -96,7 +96,7 @@ class Nyuki(metaclass=CapabilityHandler):
 
     def _exception_handler(self, loop, context):
         log.debug('Exception context: %s', context)
-        if 'exception' in context:
+        if 'exception' not in context:
             log.warning(context)
             return
 

--- a/nyuki/nyuki.py
+++ b/nyuki/nyuki.py
@@ -31,8 +31,6 @@ class Nyuki(metaclass=CapabilityHandler):
     single-threaded, asynchronous and concurrent-safe environment.
     The core engine of a nyuki implementation is the asyncio event loop
     (a single loop is used for all features).
-    A wrapper is also provide to ease the use of asynchronous calls
-    over the actions nyukis are inteded to do.
     """
 
     # Configuration schema must follow jsonschema rules.
@@ -219,7 +217,7 @@ class Nyuki(metaclass=CapabilityHandler):
 
     async def handle_report(self, body):
         """
-        Called on reception of a report from another nyuki
+        Called upon reception of a report from another nyuki
         """
         log.debug('Report received without callback')
 

--- a/nyuki/nyuki.py
+++ b/nyuki/nyuki.py
@@ -304,7 +304,9 @@ class Nyuki(metaclass=CapabilityHandler):
     class WebsocketToken:
 
         def get(self, request):
-            if not self._services.get('websocket'):
+            try:
+                self._services.get('websocket')
+            except KeyError:
                 return Response(status=404)
 
             token = self.websocket.new_token()

--- a/nyuki/reporting.py
+++ b/nyuki/reporting.py
@@ -67,5 +67,6 @@ class Reporter(object):
             'datetime': datetime.utcnow().isoformat(),
             'data': data
         }
+        self.check_report(report)
         log.info('Sending report data: %s', report)
         await self._publisher.publish(report, self._channel)

--- a/nyuki/reporting.py
+++ b/nyuki/reporting.py
@@ -1,0 +1,137 @@
+from datetime import datetime
+from enum import Enum
+from jsonschema import FormatChecker, validate, ValidationError
+import logging
+
+
+log = logging.getLogger(__name__)
+
+
+class ReportTypes(Enum):
+
+    error = {
+        'type': 'object',
+        'required': ['code', 'message'],
+        'properties': {
+            'code': {
+                'type': 'string',
+                'minLength': 1
+            },
+            'message': {
+                'type': 'string',
+                'minLength': 1
+            }
+        },
+        "additionalProperties": False
+    }
+
+    connection_lost = {
+        'type': 'object',
+        'required': ['address'],
+        'properties': {
+            'address': {
+                'type': 'string',
+                'minLength': 1
+            }
+        },
+        "additionalProperties": False
+    }
+
+    @classmethod
+    def all(cls):
+        return [item.name for item in cls]
+
+
+REPORT_SCHEMA = {
+    'type': 'object',
+    'required': ['type', 'author', 'date', 'data'],
+    'properties': {
+        'type': {
+            'type': 'string',
+            'format': 'report_type'
+        },
+        'author': {
+            'type': 'string',
+            'minLength': 1
+        },
+        'date': {
+            'type': 'string',
+            'format': 'isoformat'
+        },
+        'data': {'oneOf': [
+            {'$ref': '#/definitions/{}'.format(rtype)} for rtype in ReportTypes.all()
+        ]}
+    },
+    "additionalProperties": False,
+    'definitions': {rtype: ReportTypes[rtype].value for rtype in ReportTypes.all()}
+}
+
+
+def from_isoformat(iso):
+    return datetime.strptime(iso, '%Y-%m-%dT%H:%M:%S.%f')
+
+
+report_checker = FormatChecker()
+
+
+@report_checker.checks(format='report_type')
+def _check_report_type(rtype):
+    if rtype not in ReportTypes.all():
+        log.warning('Unknown report type: %s', rtype)
+        return False
+    return True
+
+
+@report_checker.checks(format='isoformat')
+def _check_isoformat(date):
+    try:
+        from_isoformat(date)
+    except ValueError:
+        log.warning('Unknown date format: %s', date)
+        return False
+    return True
+
+
+class Reporter(object):
+
+    def __init__(self, name, publisher):
+        if not hasattr(publisher, 'publish'):
+            raise TypeError("Nyuki publisher requires the 'publish' method")
+        self._name = name
+        self._publisher = publisher
+
+    def check_report(self, report):
+        """
+        Raise ValidationError on failure
+        """
+        validate(report, REPORT_SCHEMA, format_checker=report_checker)
+
+    async def _send_report(self, rtype, data):
+        assert rtype in ReportTypes.all()
+        report = {
+            'type': rtype,
+            'author': self._name,
+            'date': datetime.utcnow().isoformat(),
+            'data': data
+        }
+
+        try:
+            self.check_report(report)
+        except ValidationError as ve:
+            log.exception(ve)
+            log.error('Report validation failed: %s', str(ve))
+            return
+
+        log.info('Sending report data: %s', report)
+        await self._publisher.publish(report, 'reports')
+
+    async def connection_lost(self, address):
+        await self._send_report('connection_lost', {
+            'address': address
+        })
+
+    async def error(self, code, message):
+        await self._send_report('error', {
+            'code': code,
+            'message': message
+        })

--- a/nyuki/reporting.py
+++ b/nyuki/reporting.py
@@ -68,5 +68,5 @@ class Reporter(object):
             'data': data
         }
         self.check_report(report)
-        log.info('Sending report data: %s', report)
+        log.info("Sending report data with type '%s'", rtype)
         await self._publisher.publish(report, self._channel)

--- a/tests/bus_test.py
+++ b/tests/bus_test.py
@@ -82,10 +82,10 @@ class TestBus(TestCase):
             await self.bus._on_disconnect(None)
             eq_(mock.call_count, 1)
 
-    @ignore_loop
     @patch('slixmpp.xmlstream.stanzabase.StanzaBase.send')
-    def test_006_direct_message(self, send_mock):
-        self.bus.send_message('yo', {'message': 'test'})
+    async def test_006_direct_message(self, send_mock):
+        self.bus._connected.set()
+        await self.bus.send_message('yo', {'message': 'test'})
         send_mock.assert_called_once_with()
 
     async def test_007_on_direct_message(self):

--- a/tests/reporting_test.py
+++ b/tests/reporting_test.py
@@ -1,0 +1,80 @@
+from asynctest import TestCase, CoroutineMock, ignore_loop
+from datetime import datetime
+from jsonschema import ValidationError
+from nose.tools import assert_raises, eq_
+
+from nyuki.reporting import Reporter
+
+
+class ReportingTest(TestCase):
+
+    def setUp(self):
+        self.publisher = CoroutineMock()
+        self.reporter = Reporter('test', self.publisher)
+
+    @ignore_loop
+    def test_001_check_type(self):
+        with assert_raises(ValidationError):
+            self.reporter.check_report({
+                'type': 'something',
+                'author': 'test',
+                'date': datetime.utcnow().isoformat(),
+                'data': {
+                    'address': 'test'
+                }
+            })
+
+    @ignore_loop
+    def test_002_check_isoformat(self):
+        with assert_raises(ValidationError):
+            self.reporter.check_report({
+                'type': 'connection_lost',
+                'author': 'test',
+                'date': 'nope',
+                'data': {
+                    'address': 'test'
+                }
+            })
+
+    async def test_003_check_error_format(self):
+        with assert_raises(ValidationError):
+            self.reporter.check_report({
+                'type': 'error',
+                'author': 'test',
+                'date': datetime.utcnow().isoformat(),
+                'data': {
+                    'code': 'test'
+                }
+            })
+        self.reporter.check_report({
+            'type': 'error',
+            'author': 'test',
+            'date': datetime.utcnow().isoformat(),
+            'data': {
+                'code': 'test',
+                'message': 'test'
+            }
+        })
+        await self.reporter.error('123', 'test')
+        # Troubles patching datetime.utcnow
+        eq_(self.publisher.publish.call_count, 1)
+
+    async def test_004_check_connection_lost_format(self):
+        with assert_raises(ValidationError):
+            self.reporter.check_report({
+                'type': 'connection_lost',
+                'author': 'test',
+                'date': datetime.utcnow().isoformat(),
+                'data': {}
+            })
+        self.reporter.check_report({
+            'type': 'connection_lost',
+            'author': 'test',
+            'date': datetime.utcnow().isoformat(),
+            'data': {
+                'address': 'test'
+            }
+        })
+        await self.reporter.connection_lost('test')
+        # Troubles patching datetime.utcnow
+        eq_(self.publisher.publish.call_count, 1)


### PR DESCRIPTION
First draft that define the global functional perimeter.
Json validation at emission and reception and publication into the `reports` muc, for now.