### PR TITLE
Websocket token improvements

### DIFF
--- a/nyuki/websocket.py
+++ b/nyuki/websocket.py
@@ -120,6 +120,8 @@ class WebHandler(Service):
         """
         if not isinstance(message, str):
             data = json.dumps(message)
+        if isinstance(tokens, str):
+            tokens = [tokens]
         if isinstance(tokens, list):
             log.debug('Sending to client list %s: %s', tokens, data)
             for token in tokens:

--- a/nyuki/websocket.py
+++ b/nyuki/websocket.py
@@ -87,7 +87,7 @@ class WebHandler(Service):
             self._wshandler, self.host, self.port
         )
 
-    def configure(self, host='0.0.0.0', port=5559, keepalive=600):
+    def configure(self, host='0.0.0.0', port=5559, keepalive=60):
         self.host = host
         self.port = port
         self.keepalive = keepalive

--- a/nyuki/websocket.py
+++ b/nyuki/websocket.py
@@ -19,10 +19,23 @@ def websocket_ready(func):
     the return value (dict) and will be sent as data to the client
     """
     @staticmethod
-    async def decorated(self):
-        return await func(self)
+    async def decorated(self, token):
+        return await func(self, token)
 
     WebHandler.READY_CALLBACK = decorated
+    return func
+
+
+def websocket_close(func):
+    """
+    This decorator set an async method to be called at a client connection,
+    the return value (dict) and will be sent as data to the client
+    """
+    @staticmethod
+    async def decorated(self, token):
+        return await func(self, token)
+
+    WebHandler.CLOSE_CALLBACK = decorated
     return func
 
 
@@ -42,6 +55,8 @@ class WebHandler(Service):
     }
 
     READY_CALLBACK = None
+    CLOSE_CALLBACK = None
+    TOKEN_USAGE_TIMEOUT = 1
     KEEPALIVE_SCHEMA = {
         'type': 'object',
         'required': ['type'],
@@ -61,7 +76,7 @@ class WebHandler(Service):
         self.port = None
         self.server = None
         self.keepalive = None
-        self._tokens = {}
+        self.clients = {}
 
     async def start(self):
         """
@@ -93,22 +108,32 @@ class WebHandler(Service):
             for _ in range(30)
         )
         log.debug('new token: %s', token)
-        self._tokens[token] = False
+        self.clients[token] = None
+        self._loop.call_later(
+            self.TOKEN_USAGE_TIMEOUT, self._check_token_usage, token
+        )
         return token
 
-    async def broadcast(self, message):
+    async def broadcast(self, message, tokens=None):
         """
         Send a message to every connected client
         """
-        data = json.dumps(message)
-        log.debug('Sending {} to all WS clients'.format(data))
-        for websocket in self.server.websockets:
-            await websocket.send(data)
+        if not isinstance(message, str):
+            data = json.dumps(message)
+        if isinstance(tokens, list):
+            log.debug('Sending to client list %s: %s', tokens, data)
+            for token in tokens:
+                await self.clients[token].send(data)
+        else:
+            log.debug('Sending to all WS clients: %s', data)
+            for websocket in self.server.websockets:
+                await websocket.send(data)
 
-    async def send_ready(self, websocket):
+    async def _send_ready(self, websocket, token):
         """
         Send the 'ready' message to a client
         """
+        self.clients[token] = websocket
         ready = {
             'type': 'ready',
             'keepalive_delay': self.keepalive * 0.8,
@@ -116,28 +141,38 @@ class WebHandler(Service):
         }
         if self.READY_CALLBACK:
             log.info('Ready callback set up, calling it for new client')
-            ready['data'] = await self.READY_CALLBACK(self._nyuki) or {}
+            ready['data'] = await self.READY_CALLBACK(self._nyuki, token) or {}
         log.info('Sending ready packet')
         log.debug('ready dump: %s', ready)
         await websocket.send(json.dumps(ready))
 
-    def _end_websocket_client(self, websocket, token, reason):
+    def _check_token_usage(self, token):
+        """
+        Delete token if never used
+        """
+        if token in self.clients and self.clients[token] is None:
+            log.debug("token '%s' never used, deleting it", token)
+            del self.clients[token]
+
+    async def _end_websocket_client(self, websocket, token, reason):
         """
         Close the connection if no keepalive have been received
         """
+        if self.CLOSE_CALLBACK:
+            log.info('Close callback set up, calling it before ending client')
+            await self.CLOSE_CALLBACK(self._nyuki, token)
         websocket.close(reason=reason)
         try:
-            del self._tokens[token]
+            del self.clients[token]
         except KeyError as ke:
             log.debug("token '%s' already removed from keepalive", ke)
 
     def _schedule_keepalive(self, websocket, token):
         return self._loop.call_later(
             self.keepalive,
-            self._end_websocket_client,
-            websocket,
-            token,
-            'keepalive timed out'
+            lambda: asyncio.ensure_future(self._end_websocket_client(
+                websocket, token, 'keepalive timed out'
+            ), loop=self._loop)
         )
 
     async def _wshandler(self, websocket, path):
@@ -151,19 +186,18 @@ class WebHandler(Service):
             return
 
         token = match.group('token')
-        if token not in self._tokens:
+        if token not in self.clients:
             log.debug("Unknown token '%s'", token)
             websocket.close()
             return
-        elif self._tokens[token] is True:
+        elif self.clients[token] is not None:
             log.debug("Token already in use: '%s'", token)
             websocket.close()
             return
 
         log.info('Connection from token: %s', token)
-        self._tokens[token] = True
         handle = self._schedule_keepalive(websocket, token)
-        await self.send_ready(websocket)
+        await self._send_ready(websocket, token)
 
         while True:
             # Main read loop
@@ -192,4 +226,6 @@ class WebHandler(Service):
                 handle = self._schedule_keepalive(websocket, token)
 
         handle.cancel()
-        self._end_websocket_client(websocket, token, 'connection closed normally')
+        await self._end_websocket_client(
+            websocket, token, 'connection closed normally'
+        )

--- a/tests/websocket_test.py
+++ b/tests/websocket_test.py
@@ -2,6 +2,7 @@ import asyncio
 from asynctest import TestCase, patch, exhaust_callbacks
 import json
 from nose.tools import eq_, assert_raises, assert_in, assert_not_in
+import tempfile
 from websockets import client, exceptions
 
 from nyuki import Nyuki
@@ -18,9 +19,12 @@ class WebNyuki(Nyuki):
 class WebsocketTest(TestCase):
 
     async def setUp(self):
-        with patch('nyuki.config.read_default_json') as mock:
-            mock.return_value = {}
-            self.nyuki = WebNyuki(websocket={})
+        conf = tempfile.NamedTemporaryFile('w')
+        with open(conf.name, 'w') as f:
+            f.write(json.dumps({
+                'websocket': {}
+            }))
+        self.nyuki = WebNyuki(config=conf.name)
 
     async def tearDown(self):
         await self.client.close()

--- a/tests/websocket_test.py
+++ b/tests/websocket_test.py
@@ -1,5 +1,5 @@
 import asyncio
-from asynctest import TestCase, patch
+from asynctest import TestCase, patch, exhaust_callbacks
 import json
 from nose.tools import eq_, assert_raises, assert_in, assert_not_in
 from websockets import client, exceptions
@@ -51,6 +51,12 @@ class WebsocketTest(TestCase):
             'keepalive_delay': 480,
             'type': 'ready'
         })
+
+        # Token already in use
+        eq_(len(web.server.websockets), 1)
+        await client.connect('ws://localhost:5566/' + token)
+        await exhaust_callbacks(self.loop)
+        eq_(len(web.server.websockets), 1)
 
         # Close connection
         await self.client.close()


### PR DESCRIPTION
This allows a better control of websocket clients currently connected by opening a `clients` dict, receiving the connected token in the `ready` callback and implementing a `close` callback