### PR TITLE
First draft of mqtt as a bus service

### DIFF
--- a/nyuki/bus/__init__.py
+++ b/nyuki/bus/__init__.py
@@ -1,2 +1,2 @@
-from .bus import Bus
+from .xmpp import XmppBus
 from .mqtt import MqttBus

--- a/nyuki/bus/__init__.py
+++ b/nyuki/bus/__init__.py
@@ -1,1 +1,2 @@
 from .bus import Bus
+from .mqtt import MqttBus

--- a/nyuki/bus/mqtt.py
+++ b/nyuki/bus/mqtt.py
@@ -1,5 +1,6 @@
 import asyncio
-from hbmqtt.client import MQTTClient, ClientException, ConnectException
+from datetime import datetime
+from hbmqtt.client import MQTTClient, ConnectException
 from hbmqtt.errors import NoDataException
 from hbmqtt.mqtt.constants import QOS_2
 import json
@@ -7,7 +8,7 @@ import logging
 import re
 from uuid import uuid4
 
-# from nyuki.bus.persistence import BusPersistence, EventStatus, PersistenceError
+from nyuki.bus.persistence import BusPersistence, EventStatus, PersistenceError
 from nyuki.services import Service
 
 
@@ -22,14 +23,6 @@ class RequestAPI(object):
 
     async def json(self):
         return self._body
-
-
-class ReMQTTClient(MQTTClient):
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        # We handle that ourselves
-        self.config['auto_reconnect'] = False
 
 
 class MqttBus(Service):
@@ -87,56 +80,90 @@ class MqttBus(Service):
         self._loop = loop or asyncio.get_event_loop()
         self._host = None
         self._self_topic = None
-        self._request_topic = None
-        self.client = ReMQTTClient(loop=self._loop)
+        # self._request_topic = None
+        self.client = MQTTClient(
+            config={'auto_reconnect': False},
+            loop=self._loop
+        )
         self._pending = {}
         self.name = None
         self._default_callback = None
         self._subscriptions = {}
+        self._disconnection_datetime = None
 
         # Coroutines
-        self._frun = None
+        self.connect_future = None
+        self.listen_future = None
 
-    def configure(self, host, name, port=1883, certificate=None):
+    def configure(self, host, name, port=1883, certificate=None, persistence={}):
         self._host = '{}:{}'.format(host, port)
         self.name = name
         self._self_topic = self._publish_topic(self.name)
-        self._request_topic = '{}/{}/+/+'.format(self.BASE_REQ, self.name)
+        # self._request_topic = '{}/{}/+/+'.format(self.BASE_REQ, self.name)
         self._certificate = certificate
 
-    async def start(self):
-        self._frun = asyncio.ensure_future(self._run(), loop=self._loop)
+        # Persistence storage
+        self._persistence = BusPersistence(name=name, **persistence)
+        log.info('Bus persistence set to %s', self._persistence.backend)
 
-        # try:
-        #     await self._persistence.init()
-        # except PersistenceError:
-        #     log.error(
-        #         'Could not init persistence storage with %s',
-        #         self._persistence.backend
-        #     )
+    async def start(self):
+        def cancelled(future):
+            try:
+                future.result()
+            except asyncio.CancelledError:
+                log.debug('future cancelled: %s', future)
+        self.connect_future = asyncio.ensure_future(self._run())
+        self.connect_future.add_done_callback(cancelled)
+
+        try:
+            await self._persistence.init()
+        except PersistenceError:
+            log.error(
+                'Could not init persistence storage with %s',
+                self._persistence.backend
+            )
 
     async def stop(self):
         # Clean tasks
         for task in self.client.client_tasks:
             log.debug('cancelling mqtt client tasks')
             task.cancel()
-        if self._frun:
+        if self.connect_future:
             log.debug('cancelling _run coroutine')
-            self._frun.cancel()
+            self.connect_future.cancel()
+        if self.listen_future:
+            log.debug('cancelling _listen coroutine')
+            self.listen_future.cancel()
         if self.client._connected_state.is_set():
             log.debug('disconnecting mqtt client')
             await self.client.disconnect()
+        await self._persistence.close()
         log.info('MQTT service stopped')
 
     def _publish_topic(self, nyuki):
         return '{}/{}'.format(self.BASE_PUB, nyuki)
 
-    def _resp_topic_from_req(self, req_topic):
-        return re.sub(
-            r'%s/' % self.BASE_REQ,
-            r'%s/' % self.BASE_RESP,
-            req_topic
-        )
+    async def replay(self, since=None, status=None, wait=0):
+        """
+        Replay events since the given datetime (or all if None)
+        """
+        log.info('Replaying events')
+        if since:
+            log.info('    since %s', since)
+        if status:
+            log.info('    with status %s', status)
+
+        if wait:
+            log.info('Waiting %d seconds', wait)
+            await asyncio.sleep(wait)
+
+        events = await self._persistence.retrieve(since, status)
+        for event in events:
+            await self.publish(json.loads(
+                event['message']),
+                event['topic'],
+                event['id']
+            )
 
     def set_default_callback(self, callback):
         """
@@ -146,17 +173,19 @@ class MqttBus(Service):
             raise ValueError('event callback must be a coroutine')
         self._default_callback = callback
 
-    async def subscribe(self, topic, callback=None):
+    async def subscribe(self, topic, callback):
         """
-        Subscribe, with callback if given
-        (wildcards won't trigger callbacks)
+        Subscribe to a topic and setup the callback
         """
-        if callback:
-            if not asyncio.iscoroutinefunction(callback):
-                raise ValueError('event callback must be a coroutine')
-            self._subscriptions[topic] = callback
+        if not asyncio.iscoroutinefunction(callback):
+            raise ValueError('event callback must be a coroutine')
         log.debug('MQTT subscription to %s', topic)
         await self.client.subscribe([(topic, QOS_2)])
+        regex = r'^{}$'.format(
+            topic.replace('+', '[^\/]+').replace('#', '.+')
+        )
+        self._subscriptions[re.compile(regex)] = callback
+        log.info('Callback set on regex: %s', regex)
 
     async def unsubscribe(self, topic):
         """
@@ -167,53 +196,36 @@ class MqttBus(Service):
         if topic in self._subscriptions:
             del self._subscriptions[topic]
 
-    async def publish(self, data, topic=None):
+    async def publish(self, data, topic=None, previous_uid=None):
         """
         Publish in given topic or default one
         """
+        uid = previous_uid or str(uuid4())
         topic = topic or self._self_topic
         log.info('Publishing into %s', topic)
         data = json.dumps(data)
         log.debug('dump: %s', data)
-        # Implies QOS_0
-        await self.client.publish(topic, data.encode())
 
-    async def request(self, nyuki, capability, data):
-        req_topic = '{}/{}/{}/{}'.format(
-            self.BASE_REQ,
-            nyuki,
-            capability,
-            str(uuid4())[:8]
-        )
-        resp_topic = self._resp_topic_from_req(req_topic)
-        future = asyncio.Future()
-        self._pending[resp_topic] = future
+        if not self.client._connected_state.is_set():
+            status = EventStatus.PENDING
+        else:
+            # Implies QOS_0
+            await self.client.publish(topic, data.encode())
+            status = EventStatus.SENT
 
-        async def cb(data):
-            future.set_result(data)
-
-        # Subscribe to the request response
-        await self._sub(resp_topic, cb)
-        # Publish the request
-        await self.publish(data, req_topic)
-
-        # Wait for the response
-        await future
-
-        # Retrieve the response and unsubscribe
-        response = future.result()
-        del self._pending[resp_topic]
-        await self._unsub(resp_topic)
-
-        log.info('Response received: %s', response)
-        return response
-
-    async def reply(self, topic, data):
-        resp_topic = self._resp_topic_from_req(topic)
-        if not resp_topic.startswith(self.BASE_RESP + '/'):
-            log.error('Reply failure: %s', resp_topic)
-            return
-        await self.publish(data, resp_topic)
+        if previous_uid:
+            await self._persistence.update(previous_uid, status)
+        elif self._persistence:
+            await self._persistence.store({
+                'id': uid,
+                'status': status.value,
+                'topic': topic,
+                'message': data,
+            })
+            if self._persistence.memory_buffer.is_full:
+                asyncio.ensure_future(self._nyuki.on_buffer_full(
+                    self._persistence.memory_buffer.free_slot
+                ))
 
     async def _run(self):
         """
@@ -221,37 +233,42 @@ class MqttBus(Service):
         """
         delay = 1
         while True:
+            log.info('Trying MQTT connection to %s', self._host)
             try:
-                log.info('Trying MQTT connection to %s', self._host)
-                try:
-                    await self.client.connect(
-                        self._host,
-                        cafile=self._certificate
-                    )
-                except (ConnectException, NoDataException) as e:
-                    log.exception(e)
-                    current_delay = (delay * 2) + 1
-                    log.info('Waiting %d seconds to reconnect', current_delay)
-                    await asyncio.sleep(current_delay)
-                    delay = current_delay
-                    continue
+                await self.client.connect(
+                    self._host,
+                    cafile=self._certificate
+                )
+            except (ConnectException, NoDataException) as e:
+                log.exception(e)
+                # TODO: useless mechanism ?
+                current_delay = (delay * 2) + 1
+                log.info('Waiting %d seconds to reconnect', current_delay)
+                await asyncio.sleep(current_delay)
+                delay = current_delay
+                continue
 
-                # Reset reconnection delay
-                delay = 1
-                log.info('Connection made with MQTT')
-                # Subscribe to nyuki publications
-                # await self._sub()
-                # Subscribe to own requests topic
-                # await self._sub(self._request_topic, self._handle_request)
+            # Reset reconnection delay
+            delay = 1
+            log.info('Connection made with MQTT')
 
-                try:
-                    await self._listen()
-                except ClientException as e:
-                    log.exception(e)
+            # Replaying events
+            if self._persistence and self._disconnection_datetime:
+                asyncio.ensure_future(self.replay(
+                    self._disconnection_datetime,
+                    EventStatus.not_sent(),
+                    3
+                ))
 
-            except asyncio.CancelledError:
-                log.debug('Connection loop cancelled')
-                break
+            self._disconnection_datetime = None
+            # Start listening
+            self.listen_future = asyncio.ensure_future(self._listen())
+            # Blocks until mqtt is disconnected
+            await self.client._handler.wait_disconnect()
+            self._disconnection_datetime = datetime.utcnow()
+            # Clean listen_future
+            self.listen_future.cancel()
+            self.listen_future = None
 
     async def _listen(self):
         """
@@ -265,55 +282,8 @@ class MqttBus(Service):
             if topic == self._publish_topic(self.name):
                 continue
 
-            cb = self._subscriptions.get(topic, self._default_callback)
-            if not cb:
-                log.warning('no callback for event')
-                continue
-
-            asyncio.ensure_future(
-                self._handle_event(message, cb),
-                loop=self._loop
-            )
-            # Check request
-            # elif re.match(r'^%s/%s/\w+/\w{8}$' % (self.BASE_REQ, self.name), topic):
-            #     asyncio.ensure_future(self._handle_request(message), loop=self._loop)
-
-    async def _handle_event(self, message, callback):
-        """
-        Handle an event from mqtt
-        """
-        data = json.loads(message.data.decode())
-        log.debug("Event from topic '%s': %s", message.topic, data)
-        await callback(message.topic, data)
-
-    async def _handle_request(self, message):
-        """
-        Dispatch either a request or a response
-        """
-        # Check topic validity
-        m = re.match(
-            r'^(?P<mtype>\w+)/'
-            r'(?P<nyuki_name>\w+)/'
-            r'(?P<capability>\w+)/'
-            r'(?P<uuid>\w{8})$',
-            message.topic
-        )
-        if not m:
-            log.debug('Topic did not match: %s', message.topic)
-            return
-
-        data = json.loads(message.data.decode())
-        log.info("Message from topic '%s'", message.topic)
-        log.debug('dump: %s', data)
-
-        if m.group('mtype') == self.BASE_RESP and message.topic in self._pending:
-            # Is a pending response, set future result
-            self._pending[message.topic].set_result(data)
-        elif m.group('mtype') == self.BASE_REQ:
-            # Is a request
-            resp = await self._nyuki.api.call(
-                m.group('capability'), RequestAPI(data)
-            )
-            await self.reply(message.topic, resp)
-        else:
-            log.error('Message type does not match: %s', m.group('mtype'))
+            for regex, callback in self._subscriptions.items():
+                if regex.match(topic):
+                    data = json.loads(message.data.decode())
+                    log.debug("Event from topic '%s': %s", message.topic, data)
+                    asyncio.ensure_future(callback(topic, data))

--- a/nyuki/bus/reporting.py
+++ b/nyuki/bus/reporting.py
@@ -90,7 +90,7 @@ class Reporter(object):
         else:
             raise TypeError('Nyuki publisher must be XmppBus or MqttBus')
 
-    async def _handle_xmpp_report(self, data):
+    async def _handle_xmpp_report(self, efrom, data):
         """
         Handle XMPP report, ignore if it comes from this reporter
         """

--- a/nyuki/bus/reporting.py
+++ b/nyuki/bus/reporting.py
@@ -78,9 +78,9 @@ class Reporter(object):
         self._loop = loop or asyncio.get_event_loop()
         self._publisher = publisher
         self._channel = channel
-        asyncio.ensure_future(
-            self._publisher.subscribe(channel, self._handle_report)
-        )
+        asyncio.ensure_future(self._publisher.subscribe(
+            channel, self._handle_report
+        ))
 
     async def _handle_report(self, data):
         """

--- a/nyuki/bus/xmpp.py
+++ b/nyuki/bus/xmpp.py
@@ -319,7 +319,7 @@ class XmppBus(Service):
             if not asyncio.iscoroutinefunction(callback):
                 log.warning('event callbacks must be coroutines')
                 callback = asyncio.coroutine(callback)
-            await callback(body)
+            await callback(efrom, body)
         else:
             log.warning('No callback set for event from %s', efrom)
 

--- a/nyuki/bus/xmpp.py
+++ b/nyuki/bus/xmpp.py
@@ -296,9 +296,11 @@ class XmppBus(Service):
         """
         XMPP event handler when a Nyuki Event has been received.
         """
-        # ignore events from the nyuki itself
+        # Ignore events from the nyuki itself
+        # Event's resource is checked as well in case of self monitoring:
+        # 'monitoring@mucs.localhost/this_nyuki'
         efrom = event['from'].user
-        if efrom == self._topic:
+        if efrom == self._topic or event['from'].resource == self._topic:
             future = self._publish_futures.get(event['id'])
             if not future:
                 log.warning('Received own publish that was not in memory')

--- a/nyuki/bus/xmpp.py
+++ b/nyuki/bus/xmpp.py
@@ -74,6 +74,7 @@ class XmppBus(Service):
     subscribe to any other topics to process events from other nyukis.
     """
 
+    SERVICE = 'xmpp'
     CONF_SCHEMA = {
         "type": "object",
         "required": ["bus"],
@@ -196,7 +197,7 @@ class XmppBus(Service):
         """
         Initialize reporting module
         """
-        reporting.init(self.client.boundjid.user, self, self._report_channel)
+        reporting.init(self.client.boundjid.user, self)
 
     def _muc_address(self, topic):
         return '{}@{}'.format(topic, self._muc_domain)

--- a/nyuki/bus/xmpp.py
+++ b/nyuki/bus/xmpp.py
@@ -18,7 +18,7 @@ class PublishError(Exception):
     pass
 
 
-class _BusClient(ClientXMPP):
+class _XmppClient(ClientXMPP):
 
     """
     XMPP client to connect to the bus.
@@ -65,7 +65,7 @@ class _BusClient(ClientXMPP):
         reporting.exception(exc)
 
 
-class Bus(Service):
+class XmppBus(Service):
 
     """
     A simple class that implements Publish/Subscribe-like communications over
@@ -158,7 +158,7 @@ class Bus(Service):
                   muc_domain='mucs.localhost', certificate=None,
                   persistence={}):
         # XMPP client and main handlers
-        self.client = _BusClient(
+        self.client = _XmppClient(
             jid, password, host, port, certificate=certificate
         )
         self.client.loop = self._loop

--- a/nyuki/capabilities.py
+++ b/nyuki/capabilities.py
@@ -116,8 +116,4 @@ class Exposer(Service):
             log.warning('No such capability: %s', name)
             return
 
-        response = await capa.wrapper(body)
-        if response.headers.get('content-type') == 'application/json':
-            return response.body
-        else:
-            return json.dumps({'result': response.body})
+        return asyncio.ensure_future(capa.wrapper(body), loop=self._loop)

--- a/nyuki/mqtt.py
+++ b/nyuki/mqtt.py
@@ -1,0 +1,236 @@
+import asyncio
+from hbmqtt.client import MQTTClient, ClientException, ConnectException
+from hbmqtt.errors import NoDataException
+from hbmqtt.mqtt.constants import QOS_2
+import json
+import logging
+import re
+from uuid import uuid4
+
+from nyuki.services import Service
+
+
+log = logging.getLogger(__name__)
+
+
+class Request(object):
+
+    def __init__(self, nyuki, capability, uuid):
+        pass
+
+
+class ReMQTTClient(MQTTClient):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # We handle that ourselves
+        self.config['auto_reconnect'] = False
+
+
+class MqttBus(Service):
+
+    """
+    Nyuki topics formatted as:
+        - global publications:
+            {nyuki_name}/publications
+        - request/response:
+            {nyuki_name}/{capability_name}/{request_id}/<request|response>
+    """
+
+    def __init__(self, nyuki):
+        self._nyuki = nyuki
+        self._loop = nyuki.loop or asyncio.get_event_loop()
+        self._host = None
+        self._self_topic = None
+        self._request_topic = None
+        self.client = ReMQTTClient(loop=self._loop)
+        self._pending = {}
+        self._subscriptions = {}
+
+        # Coroutines
+        self._frun = None
+
+    def configure(self, host, name):
+        self._host = host
+        self._name = name
+        self._self_topic = '{}/publications'.format(self._name)
+        self._request_topic = '{}/+/+/request'.format(self._name)
+
+    async def start(self):
+        self._frun = asyncio.ensure_future(self._run(), loop=self._loop)
+
+    async def stop(self):
+        # Clean tasks
+        for task in self.client.client_tasks:
+            log.debug('cancelling mqtt client tasks')
+            task.cancel()
+        if self._frun:
+            log.debug('cancelling _run coroutine')
+            self._frun.cancel()
+        if self.client._connected_state.is_set():
+            log.debug('disconnecting mqtt client')
+            await self.client.disconnect()
+        log.info('MQTT service stopped')
+
+    def _publish_topic(self, nyuki):
+        return '{}/publications'.format(nyuki)
+
+    def _resp_topic_from_req(self, req_topic):
+        return req_topic.replace('/request', '/response')
+
+    async def _sub(self, topic, callback):
+        log.debug('MQTT subscription to %s', topic)
+        await self.client.subscribe([(topic, QOS_2)])
+
+        if not asyncio.iscoroutinefunction(callback):
+            log.warning('event callback must be a coroutine')
+            callback = asyncio.coroutine(callback)
+        self._subscriptions[topic] = callback
+
+    async def _unsub(self, topic):
+        log.debug('MQTT unsubscription from %s', topic)
+        await self.client.unsubscribe([topic])
+        if topic in self._subscriptions:
+            del self._subscriptions[topic]
+
+    async def subscribe(self, nyuki, callback):
+        log.info('Subscribing to %s', nyuki)
+        topic = self._publish_topic(nyuki)
+        await self._sub(topic, callback)
+
+    async def unsubscribe(self, nyuki):
+        log.info('Unsubscribing from %s', nyuki)
+        topic = self._publish_topic(nyuki)
+        await self._unsub(topic)
+
+    async def publish(self, data, topic=None):
+        topic = topic or self._self_topic
+        log.info('Publishing into %s', topic)
+        data = json.dumps(data)
+        log.debug('dump: %s', data)
+        # Implies QOS_0
+        await self.client.publish(topic, data.encode())
+
+    async def request(self, nyuki, capability, data):
+        req_topic = '{}/{}/{}/request'.format(nyuki, capability, str(uuid4())[:8])
+        resp_topic = self._resp_topic_from_req(req_topic)
+        future = asyncio.Future()
+        self._pending[resp_topic] = future
+
+        async def cb(data):
+            future.set_result(data)
+
+        # Subscribe to the request response
+        await self._sub(resp_topic, cb)
+        # Publish the request
+        await self.publish(data, req_topic)
+
+        # Wait for the response
+        await future
+
+        # Retrieve the response and unsubscribe
+        response = future.result()
+        del self._pending[resp_topic]
+        await self._unsub(resp_topic)
+
+        log.info('Response received: %s', response)
+        return response
+
+    async def reply(self, topic, data):
+        resp_topic = self._resp_topic_from_req(topic)
+        if not resp_topic.endswith('/response'):
+            log.error('Reply failure: %s', resp_topic)
+            return
+        await self.publish(data, resp_topic)
+
+    async def _run(self):
+        """
+        Handle reconnection every (last * 2) + 1 seconds
+        """
+        delay = 1
+        while True:
+            try:
+                log.info('Trying MQTT connection to %s', self._host)
+                try:
+                    await self.client.connect(self._host, cafile='ssl/ca.crt')
+                except (ConnectException, NoDataException) as e:
+                    log.error(e)
+                    current_delay = (delay * 2) + 1
+                    log.info('Waiting %d seconds to reconnect', current_delay)
+                    await asyncio.sleep(current_delay)
+                    delay = current_delay
+                    continue
+
+                # Reset reconnection delay
+                delay = 1
+                log.info('Connection made with MQTT')
+                # Subscribe to own requests topic
+                await self._sub(self._request_topic, self._handle_request)
+
+                try:
+                    await self._listen()
+                except ClientException as e:
+                    log.error(e)
+
+            except asyncio.CancelledError:
+                log.debug('Connection loop cancelled')
+                break
+
+    async def _listen(self):
+        while True:
+            message = await self.client.deliver_message()
+            topic = message.topic
+
+            # Ignore own message
+            if topic == self._publish_topic(self._name):
+                return
+
+            # Check subscription event
+            if topic in self._subscriptions:
+                asyncio.ensure_future(self._handle_event(message), loop=self._loop)
+            # Check request
+            elif re.match(r'^%s/\w+/\w{8}/request$' % self._name, topic):
+                asyncio.ensure_future(self._handle_request(message), loop=self._loop)
+            else:
+                log.debug('Unknown event received on topic: %s', topic)
+
+    async def _handle_event(self, message):
+        """
+        Handle an event from a subscribed topic
+        """
+        data = json.loads(message.data.decode())
+        log.info("Event from topic '%s'", message.topic)
+        log.debug('dump: %s', data)
+
+        callback = self._subscriptions[message.topic]
+        await callback(data)
+
+    async def _handle_request(self, message):
+        """
+        Dispatch either a request or a response
+        """
+        # Check topic validity
+        m = re.match(
+            r'^(?P<nyuki_name>\w+)/'
+            r'(?P<capability>\w+)/'
+            r'(?P<uuid>\w{8})/'
+            r'(?P<mtype>\w+)$',
+            message.topic
+        )
+        if not m:
+            log.debug('Topic did not match: %s', message.topic)
+            return
+
+        data = json.loads(message.data.decode())
+        log.info("Message from topic '%s'", message.topic)
+        log.debug('dump: %s', data)
+
+        if m.group('mtype') == 'response' and message.topic in self._pending:
+            # Is a pending response, set future result
+            self._pending[message.topic].set_result(data)
+        elif m.group('mtype') == 'request':
+            # Is a request
+            resp = await self._nyuki.api.call(m.group('capability'), data)
+            await self.reply(message.topic, resp)
+        else:
+            log.error('Message type does not match: %s', m.group('mtype'))

--- a/nyuki/nyuki.py
+++ b/nyuki/nyuki.py
@@ -7,8 +7,7 @@ from pijon import Pijon
 from signal import SIGHUP, SIGINT, SIGTERM
 import uvloop
 
-from nyuki import reporting
-from nyuki.api import Response
+from nyuki import reporting, Response
 from nyuki.bus import Bus, MqttBus
 from nyuki.bus.persistence import EventStatus
 from nyuki.capabilities import Exposer, resource

--- a/nyuki/nyuki.py
+++ b/nyuki/nyuki.py
@@ -15,6 +15,7 @@ from nyuki.commands import get_command_kwargs
 from nyuki.config import get_full_config, write_conf_json, merge_configs
 from nyuki.handlers import CapabilityHandler
 from nyuki.logs import DEFAULT_LOGGING
+from nyuki.mqtt import MqttBus
 from nyuki.services import ServiceManager
 from nyuki.utils import from_isoformat
 from nyuki.websocket import WebHandler
@@ -76,6 +77,9 @@ class Nyuki(metaclass=CapabilityHandler):
         # Add websocket server if in conf file
         if self._config.get('websocket') is not None:
             self._services.add('websocket', WebHandler(self))
+        # Add mqtt service if in conf file
+        if self._config.get('mqtt') is not None:
+            self._services.add('mqtt', MqttBus(self))
 
         self.is_stopping = False
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 aiohttp>=0.21,<0.22
+hbmqtt>=0.7,<0.8
 jsonschema>=2.5,<2.6
 motor>=0.6,<0.7
 pijon>=0.1,<0.2
@@ -6,4 +7,4 @@ pijon>=0.1,<0.2
 pycares==1.0.0
 slixmpp>=1.1,<1.2
 tukio>=0.4,<0.5
-websockets>=3.0,<3.1
+websockets>=3.1,<3.2

--- a/tests/nyuki_test.py
+++ b/tests/nyuki_test.py
@@ -42,7 +42,7 @@ class TestNyuki(TestCase):
         response = self.nyuki.Configuration.get(self.nyuki, None)
         eq_(json.loads(bytes.decode(response.body)), self.nyuki._config)
 
-    @patch('nyuki.bus.Bus.stop')
+    @patch('nyuki.bus.XmppBus.stop')
     async def test_004_patch_rest_configuration(self, bus_stop_mock):
         req = Mock()
         async def json():

--- a/tests/reporting_test.py
+++ b/tests/reporting_test.py
@@ -10,7 +10,8 @@ class ReportingTest(TestCase):
 
     def setUp(self):
         self.publisher = CoroutineMock()
-        reporting.init('test', self.publisher, 'errors')
+        self.publisher.SERVICE = 'xmpp'
+        reporting.init('test', self.publisher)
 
     async def tearDown(self):
         await exhaust_callbacks(self.loop)

--- a/tests/xmpp_test.py
+++ b/tests/xmpp_test.py
@@ -53,7 +53,7 @@ class TestXmppBus(TestCase):
         msg['from'] = JID('someone@localhost')
         msg['body'] = '{"key": "value"}'
         await self.bus._on_event(msg)
-        cb.assert_called_once_with({'key': 'value'})
+        cb.assert_called_once_with('someone', {'key': 'value'})
 
     @patch('slixmpp.xmlstream.stanzabase.StanzaBase.send')
     async def test_003a_publish(self, send_mock):

--- a/tests/xmpp_test.py
+++ b/tests/xmpp_test.py
@@ -5,14 +5,14 @@ from asynctest import (
 from nose.tools import assert_raises, eq_
 from slixmpp import JID
 
-from nyuki.bus.bus import _BusClient, Bus
+from nyuki.bus.xmpp import _XmppClient, XmppBus
 from nyuki.bus.persistence import EventStatus
 
 
 class TestBusClient(TestCase):
 
     def setUp(self):
-        self.client = _BusClient('test@localhost', 'password')
+        self.client = _XmppClient('test@localhost', 'password')
 
     @ignore_loop
     def test_001a_init(self):
@@ -24,16 +24,16 @@ class TestBusClient(TestCase):
     @ignore_loop
     def test_001b_init(self):
         # Ensure bus client instanciation (method 2)
-        client = _BusClient('test', 'password', '127.0.0.1', 5555)
+        client = _XmppClient('test', 'password', '127.0.0.1', 5555)
         host, port = client._address
         eq_(host, '127.0.0.1')
         eq_(port, 5555)
 
 
-class TestBus(TestCase):
+class TestXmppBus(TestCase):
 
     def setUp(self):
-        self.bus = Bus(Mock())
+        self.bus = XmppBus(Mock())
         self.bus.configure('test@localhost', 'password')
 
     @ignore_loop
@@ -114,7 +114,7 @@ class TestBus(TestCase):
             })
 
     @patch('slixmpp.xmlstream.stanzabase.StanzaBase.send', Mock)
-    @patch('nyuki.bus.Bus.subscribe')
+    @patch('nyuki.bus.XmppBus.subscribe')
     async def test_008_stream_error_resubscribe(self, submock):
         self.bus._connected.set()
         self.loop.call_later(0.1, asyncio.ensure_future, self.stream_error())
@@ -123,7 +123,7 @@ class TestBus(TestCase):
         submock.assert_called_once_with('test', None)
 
     @patch('slixmpp.xmlstream.stanzabase.StanzaBase.send', Mock)
-    @patch('nyuki.bus.Bus.subscribe')
+    @patch('nyuki.bus.XmppBus.subscribe')
     async def test_009_failed_publish_resubscribe(self, submock):
         self.bus._connected.set()
         self.loop.call_later(0.1, asyncio.ensure_future, self.publish_fail())
@@ -154,7 +154,7 @@ class TestMongoPersistence(TestCase):
 
     @patch('nyuki.bus.persistence.mongo_backend.MongoBackend.init')
     async def setUp(self, init):
-        self.bus = Bus(Mock())
+        self.bus = XmppBus(Mock())
         self.bus.configure(
             'test@localhost', 'password',
             persistence={'backend': 'mongo'}


### PR DESCRIPTION
## Run
Configuration to enable mqtt :
```
{
    "bus": {
        "service": "mqtt",       (default: xmpp)
        "name": "testnyuki",     (required to identify the nyuki)
        "scheme": "ws",
        "host": "localhost"
    }
}
```
Start the mqtt broker using :
```bash
docker pull surycat/mosquitto:unsecure
docker run -it -p 1883:1883 surycat/mosquitto:unsecure
```
## Usage
Listen to a mqtt pattern (starts with `publications/` and anything after)
```python
async def handle_pub(topic, data):
    print(topic)
    print(data)

await self.bus.subscribe('publications/#', handle_pub)
```
Publish to a mqtt topic
```python
# Implies topic='publications/nyuki_name'
await self.bus.publish({'something': 'here'})
await self.bus.publish({'something': 'here'}, topic='a/custom/topic')
```