### PR TITLE
Allow multiple callbacks on one topic, add API exception shortcut

### DIFF
--- a/nyuki/api/__init__.py
+++ b/nyuki/api/__init__.py
@@ -1,1 +1,1 @@
-from .api import Response, Api, resource, content_type
+from .api import Response, Api, resource, content_type, HTTPBreak

--- a/nyuki/api/api.py
+++ b/nyuki/api/api.py
@@ -36,6 +36,13 @@ def content_type(content_type):
     return decorated
 
 
+class HTTPBreak(Exception):
+
+    def __init__(self, status, body=None):
+        self.status = status
+        self.body = body
+
+
 class Response(web.Response):
 
     """
@@ -112,13 +119,14 @@ async def mw_capability(app, capa_handler):
         except (web.HTTPNotFound, web.HTTPMethodNotAllowed):
             # Avoid sending a report on a simple 404/405
             raise
+        except HTTPBreak as exc:
+            return Response(exc.body, status=exc.status)
         except Exception as exc:
             reporting.exception(exc)
             raise
 
         if capa_resp and isinstance(capa_resp, Response):
             return capa_resp
-
         return Response()
 
     return middleware

--- a/nyuki/bus/xmpp.py
+++ b/nyuki/bus/xmpp.py
@@ -444,7 +444,7 @@ class XmppBus(Service):
 
         # '/' are not supported in MUCs name
         topic = topic.replace('/', '.')
-        self._mucs.joinMUC(self._muc_address(topic), self.name)
+        self._mucs.join_muc(self._muc_address(topic), self.name)
         log.info("Subscribed to '%s'", topic)
         if self._callbacks.get(topic) is None:
             self._callbacks[topic] = callback

--- a/nyuki/bus/xmpp.py
+++ b/nyuki/bus/xmpp.py
@@ -1,14 +1,12 @@
 import asyncio
 import json
 import logging
-import re
 from slixmpp import ClientXMPP
 from slixmpp.exceptions import IqError, IqTimeout
 from uuid import uuid4
 
 from nyuki.bus import reporting
 from nyuki.services import Service
-
 from .persistence import BusPersistence, EventStatus, PersistenceError
 from .utils import serialize_bus_event
 
@@ -219,7 +217,7 @@ class XmppBus(Service):
             log.debug("Could not register account: {}".format(error))
         except IqTimeout:
             log.error("No response from the server")
-        finally:
+        else:
             log.debug("Account {} created".format(self.client.boundjid))
 
     async def _on_start(self, event):

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ motor>=1.1,<1.2
 pijon>=0.1,<0.2
 # pycares-2.0.0 breaks errno.ECONNRESET
 # pycares==1.0.0
-slixmpp>=1.1,<1.2
+slixmpp>=1.2,<1.3
 tukio>=0.11,<0.12
 websockets>=3.2,<3.3
 aioredis>=0.3,<0.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
-aiohttp>=1.1,<1.2
+aiohttp>=1.2,<1.3
 hbmqtt>=0.8,<0.9
 jsonschema>=2.5,<2.6
-motor>=1.0,<1.1
+motor>=1.1,<1.2
 pijon>=0.1,<0.2
 # pycares-2.0.0 breaks errno.ECONNRESET
-pycares==1.0.0
+# pycares==1.0.0
 slixmpp>=1.1,<1.2
 tukio>=0.11,<0.12
 websockets>=3.2,<3.3

--- a/tests/capabilities_test.py
+++ b/tests/capabilities_test.py
@@ -52,7 +52,8 @@ class TestResourceClass(TestCase):
 
     @patch('aiohttp.web_urldispatcher.Resource.add_route')
     def test_001_register(self, add_route):
-        router = UrlDispatcher(Mock())
+        router = UrlDispatcher()
+        router.post_init(Mock())
         self.resource_cls.register(Mock(), router)
         # GET /v1/test
         # DELETE /v1/test

--- a/tests/xmpp_test.py
+++ b/tests/xmpp_test.py
@@ -44,7 +44,7 @@ class TestXmppBus(TestCase):
     async def test_002_on_event(self):
         self.bus._connected.set()
         cb = CoroutineMock()
-        with patch.object(self.bus._mucs, 'joinMUC') as join_mock:
+        with patch.object(self.bus._mucs, 'join_muc') as join_mock:
             await self.bus.subscribe('someone', cb)
             join_mock.assert_called_once_with('someone@mucs.localhost', 'test')
         msg = self.bus.client.Message()
@@ -78,7 +78,7 @@ class TestXmppBus(TestCase):
     @patch('slixmpp.xmlstream.stanzabase.StanzaBase.send')
     async def test_003d_publish_unknown_topic(self, send_mock):
         self.bus._connected.set()
-        with patch.object(self.bus._mucs, 'joinMUC') as join_mock:
+        with patch.object(self.bus._mucs, 'join_muc') as join_mock:
             asyncio.ensure_future(self.bus.publish({'test': 'message'}, 'unknown/topic'))
             await exhaust_callbacks(self.loop)
             join_mock.assert_called_once_with('unknown.topic@mucs.localhost', 'test')


### PR DESCRIPTION
This adds:
* Return HTTP responses from anywhere in the code using exceptions.
```python
raise HTTPBreak(404)
```
* Subscribe to a topic and call multiple methods on message received, instead of overriding the previous method.
```python
await bus.subscribe('some/topic', my_method)
await bus.subscribe('some/topic', my_second_method)
```
* Resubscribe to all topics and callbacks when the connection is lost and reconnected (as it did in the xmpp implementation).