### PR TITLE
Update examples config files

### DIFF
--- a/examples/pumba.json
+++ b/examples/pumba.json
@@ -4,11 +4,8 @@
 		"port": 8081
 	},
 	"bus": {
-		"service": "mqtt",
-		"scheme": "ws",
-		"host": "localhost",
-		"port": 1883,
-		"name": "pumba"
+		"dsn": "mqtt://pumba@localhost:1883",
+		"keep_alive": 10
 	},
 	"version": 0
 }

--- a/examples/timon.json
+++ b/examples/timon.json
@@ -4,11 +4,8 @@
 		"port": 8080
 	},
 	"bus": {
-		"service": "mqtt",
-		"scheme": "ws",
-		"host": "localhost",
-		"port": 1883,
-		"name": "timon"
+		"dsn": "mqtt://timon@localhost:1883",
+		"keep_alive": 10
 	},
 	"version": 0
 }


### PR DESCRIPTION
The current config files for the examples are outdated and raises jsonschema exceptions, tested with these configurations and it works as expected.